### PR TITLE
fix u256str cmp issue

### DIFF
--- a/types/common_test.go
+++ b/types/common_test.go
@@ -57,3 +57,21 @@ func TestU256Str(t *testing.T) {
 	u := IntToU256(123)
 	require.Equal(t, "123", u.String())
 }
+
+func TestU256StrCmp(t *testing.T) {
+	one := IntToU256(1)
+	two := IntToU256(2)
+	bigger := IntToU256(256)
+	require.Equal(t, "1", one.String())
+	require.Equal(t, "2", two.String())
+	require.Equal(t, "256", bigger.String())
+
+	require.Equal(t, 0, one.Cmp(&one))
+	require.Equal(t, 0, bigger.Cmp(&bigger))
+
+	require.Equal(t, -1, one.Cmp(&two))
+	require.Equal(t, -1, one.Cmp(&bigger))
+
+	require.Equal(t, 1, bigger.Cmp(&two))
+	require.Equal(t, 1, bigger.Cmp(&one))
+}

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,11 +1,19 @@
 package types
 
-import "bytes"
+import (
+	"math/big"
+)
+
+func (n *U256Str) BigInt() *big.Int {
+	return new(big.Int).SetBytes(reverse(n[:]))
+}
 
 // Cmp compares one U256Str to another and returns an integer indicating whether a > b.
 // The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
 func (n *U256Str) Cmp(b *U256Str) int {
-	return bytes.Compare(n[:], b[:])
+	_a := n.BigInt()
+	_b := b.BigInt()
+	return _a.Cmp(_b)
 }
 
 // HexToAddress takes a hex string and returns an Address


### PR DESCRIPTION
Related issue(s):

#11 

Solved by converting the U256Str types to `big.Int` and comparing this way. Thanks @jtraglia

---

I have run these commands:

* [X] `make lint`
* [X] `make test`
