### PR TITLE
Remove misleading bls comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Write here the instructions to set up the development environment.
 
 ## Test
 
-Write here the intructions to run the tests.
+Write here the instructions to run the tests.
 
 ## Code style
 

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -19,13 +19,12 @@ type PublicKey = blst.P1Affine
 type SecretKey = blst.SecretKey
 type Signature = blst.P2Affine
 
-// PublicKeyFromBytes creates a BLS public key from a  BigEndian byte slice.
 func PublicKeyFromBytes(pkBytes []byte) (*PublicKey, error) {
 	if len(pkBytes) != BLSPublicKeyLength {
 		return nil, errors.New("invalid pubkey length")
 	}
 
-	pk := new(blst.P1Affine).Uncompress(pkBytes)
+	pk := new(PublicKey).Uncompress(pkBytes)
 	if pk == nil {
 		return nil, errors.New("could not uncompress public key from bytes")
 	}
@@ -45,7 +44,7 @@ func SecretKeyFromBytes(skBytes []byte) (*SecretKey, error) {
 	if len(skBytes) != BLSSecretKeyLength {
 		return nil, errors.New("invalid secret key length")
 	}
-	secretKey := new(blst.SecretKey).Deserialize(skBytes)
+	secretKey := new(SecretKey).Deserialize(skBytes)
 	if secretKey == nil {
 		return nil, errors.New("could not deserialize secret key from bytes")
 	}
@@ -74,13 +73,12 @@ func Sign(sk *SecretKey, msg []byte) *Signature {
 	return new(Signature).Sign(sk, msg, dst)
 }
 
-// SignatureFromBytes creates a BLS signature from a LittleEndian byte slice.
 func SignatureFromBytes(sigBytes []byte) (*Signature, error) {
 	if len(sigBytes) != BLSSignatureLength {
 		return nil, errors.New("invalid signature length")
 	}
 
-	sig := new(blst.P2Affine).Uncompress(sigBytes)
+	sig := new(Signature).Uncompress(sigBytes)
 	if sig == nil {
 		return nil, errors.New("could not uncompress signature from bytes")
 	}

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -26,11 +26,11 @@ func TestSecretToPubkey(t *testing.T) {
 // Stolen from Teku's BLSTest class:
 // https://github.com/ConsenSys/teku/blob/ce6e13e32f2c5029aa05895f400c00a9c72a3f38/infrastructure/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java#L318-L332
 func TestSignatureVerifyRealValues(t *testing.T) {
-    signingRootBytes := hexutil.MustDecode("0x95b8e2ba063ab62f68ebe7db0a9669ab9e7906aa4e060e1cc0b67b294ce8c5e4")
-    sigBytes := hexutil.MustDecode("0xab51f352e90509ca5085ec43af9ad3ea4ae42bf30c91af7dcdc113ef79cfc8601b756f18d8cf634436d8b6b0095fc5680066f382eb3728a7090c55c9afb66e8f94b44d2682db8ef5de4b89928d1744824df174e0c800b9e934b0ad14e6388163")
-    pkBytes := hexutil.MustDecode("0xb5e8f551c28abd6ef8253581ffad0834bfd8fafa9948d09b337c9c5f21d6e7fd6065a1ee35ac5146ac17344f97490301")
+	signingRootBytes := hexutil.MustDecode("0x95b8e2ba063ab62f68ebe7db0a9669ab9e7906aa4e060e1cc0b67b294ce8c5e4")
+	sigBytes := hexutil.MustDecode("0xab51f352e90509ca5085ec43af9ad3ea4ae42bf30c91af7dcdc113ef79cfc8601b756f18d8cf634436d8b6b0095fc5680066f382eb3728a7090c55c9afb66e8f94b44d2682db8ef5de4b89928d1744824df174e0c800b9e934b0ad14e6388163")
+	pkBytes := hexutil.MustDecode("0xb5e8f551c28abd6ef8253581ffad0834bfd8fafa9948d09b337c9c5f21d6e7fd6065a1ee35ac5146ac17344f97490301")
 
-    result, err := VerifySignatureBytes(signingRootBytes, sigBytes, pkBytes)
-    require.NoError(t, err)
-    require.Equal(t, result, true)
+	result, err := VerifySignatureBytes(signingRootBytes, sigBytes, pkBytes)
+	require.NoError(t, err)
+	require.Equal(t, result, true)
 }

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -22,3 +22,15 @@ func TestSecretToPubkey(t *testing.T) {
 		require.Equal(t, pk.Compress(), tc.Output)
 	}
 }
+
+// Stolen from Teku's BLSTest class:
+// https://github.com/ConsenSys/teku/blob/ce6e13e32f2c5029aa05895f400c00a9c72a3f38/infrastructure/bls/src/test/java/tech/pegasys/teku/bls/BLSTest.java#L318-L332
+func TestSignatureVerifyRealValues(t *testing.T) {
+    signingRootBytes := hexutil.MustDecode("0x95b8e2ba063ab62f68ebe7db0a9669ab9e7906aa4e060e1cc0b67b294ce8c5e4")
+    sigBytes := hexutil.MustDecode("0xab51f352e90509ca5085ec43af9ad3ea4ae42bf30c91af7dcdc113ef79cfc8601b756f18d8cf634436d8b6b0095fc5680066f382eb3728a7090c55c9afb66e8f94b44d2682db8ef5de4b89928d1744824df174e0c800b9e934b0ad14e6388163")
+    pkBytes := hexutil.MustDecode("0xb5e8f551c28abd6ef8253581ffad0834bfd8fafa9948d09b337c9c5f21d6e7fd6065a1ee35ac5146ac17344f97490301")
+
+    result, err := VerifySignatureBytes(signingRootBytes, sigBytes, pkBytes)
+    require.NoError(t, err)
+    require.Equal(t, result, true)
+}


### PR DESCRIPTION
## 📝 Summary

* Fix typo in contributing guidelines document.
* Remove comments from pk/sig `*FromBytes` functions.
  * I believe that the `SignatureFromBytes` comment is misleading.
  * The public key and signature are big-endian, right? (see reference)
* Use easier to read BLST types which are defined at the top of the file.
* For sanity, add a signature verification test, stolen from Teku.

## ⛱ Motivation and Context

When looking over this file, the little-endian/big-endian difference seemed odd.

## 📚 References

* https://ethresear.ch/t/bls12-381-keys-and-signatures-sizes/6152/3

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`