### PR TITLE
Bench signature verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ build:
 test:
 	go test ./...
 
+bench:
+	go test -benchmem -bench=. ./...
+
 lint:
 	gofmt -d ./
 	go vet ./...


### PR DESCRIPTION
## 📝 Summary

Add a benchmark for signature verification

`make bench` outputs:

aws i3en.large - cpu: Intel(R) Xeon(R) Platinum 8175M CPU @ 2.50GHz

```bash
BenchmarkSignatureVerification-2   	     705	   1,735,334 ns/op
```

aws m1.metal

```bash
BenchmarkSignatureVerification-16    	     223	   5,377,079 ns/op
```

m1 max mbp - cpu: VirtualApple @ 2.50GHz

```bash
BenchmarkSignatureVerification-10            784           1,502,121 ns/op
```

Hetzner: cpu: AMD Ryzen 7 3700X 8-Core Processor

```
BenchmarkSignatureVerification-16    	     872	   1,313,259 ns/op
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
