### PR TITLE
Fix IndexedAttestation decoding

### DIFF
--- a/types/builder_test.go
+++ b/types/builder_test.go
@@ -203,3 +203,30 @@ func TestMerkelizePayload(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "87b57a69321ec21e8a83a39f2f0f885a3be9bbddb80794b3b2700c3cf8230aa1", common.Bytes2Hex(root[:]))
 }
+
+func TestIndexedAttestation(t *testing.T) {
+    input := `
+    {
+      "attesting_indices": [
+        "1", "2", "3"
+      ],
+      "signature": "0x1c66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
+      "data": {
+        "slot": "1",
+        "index": "1",
+        "beacon_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+        "source": {
+          "epoch": "1",
+          "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+        },
+        "target": {
+          "epoch": "1",
+          "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+        }
+      }
+    }
+    `
+	var result IndexedAttestation
+	err := json.Unmarshal([]byte(input), &result)
+	require.NoError(t, err)
+}

--- a/types/builder_test.go
+++ b/types/builder_test.go
@@ -205,27 +205,25 @@ func TestMerkelizePayload(t *testing.T) {
 }
 
 func TestIndexedAttestation(t *testing.T) {
-    input := `
-    {
-      "attesting_indices": [
-        "1", "2", "3"
-      ],
-      "signature": "0x1c66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
-      "data": {
-        "slot": "1",
-        "index": "1",
-        "beacon_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
-        "source": {
-          "epoch": "1",
-          "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-        },
-        "target": {
-          "epoch": "1",
-          "root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-        }
-      }
-    }
-    `
+	input := `{
+		"attesting_indices": [
+			"1", "2", "3"
+		],
+		"signature": "0x1c66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505",
+		"data": {
+			"slot": "1",
+			"index": "1",
+			"beacon_block_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+			"source": {
+				"epoch": "1",
+				"root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+			},
+			"target": {
+				"epoch": "1",
+				"root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+			}
+		}
+	}`
 	var result IndexedAttestation
 	err := json.Unmarshal([]byte(input), &result)
 	require.NoError(t, err)


### PR DESCRIPTION
## 📝 Summary

When reviewing builder types, I noticed that the json encoding for `AttestingIndices` is missing the `string` option. The beacon API states (see reference for example) that this should be a list of `uint64` strings.

https://github.com/flashbots/go-boost-utils/blob/417a64679a5d4a2c12b64ff7ee918243d4ab34eb/types/builder.go#L62

I was expecting to see something like `json:"attesting_indices,string"` but I know that won't work.

Other `uint64` fields are told to be strings, for example:

https://github.com/flashbots/go-boost-utils/blob/417a64679a5d4a2c12b64ff7ee918243d4ab34eb/types/builder.go#L53

I made a test to verify my theory. I've included it here. Keep in mind it will currently fail with this message:

```
make test
go test ./...
ok  	github.com/flashbots/go-boost-utils/bls	(cached)
--- FAIL: TestIndexedAttestation (0.00s)
    builder_test.go:231:
        	Error Trace:	builder_test.go:231
        	Error:      	Received unexpected error:
        	            	json: cannot unmarshal string into Go struct field IndexedAttestation.attesting_indices of type uint64
        	Test:       	TestIndexedAttestation
FAIL
FAIL	github.com/flashbots/go-boost-utils/types	0.114s
FAIL
make: *** [test] Error 1
```

It will pass if you change `attesting_indices` from this to that:

```json
"attesting_indices": [
        "1", "2", "3"
      ],
```

```json
"attesting_indices": [
        1, 2, 3
      ],
```

Opening as a draft because I'm not entirely sure what the proper fix it. Would like to discuss.

## ⛱ Motivation and Context

There's a minor problem with `IndexedAttestation` encoding/decoding that should be fixed.

## 📚 References

* https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttesterSlashings
* https://stackoverflow.com/questions/49415573/golang-json-how-do-i-unmarshal-array-of-strings-into-int64

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
