### PR TITLE
Throw error if input for `U256Str` is invalid

### DIFF
--- a/types/common.go
+++ b/types/common.go
@@ -252,7 +252,10 @@ func (n *U256Str) UnmarshalJSON(input []byte) error {
 	if err != nil {
 		return err
 	}
-	copy(n[:], reverse(x.FillBytes(n[:])))
+	err = n.FromBig(x)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -262,7 +265,10 @@ func (n *U256Str) UnmarshalText(input []byte) error {
 	if err != nil {
 		return err
 	}
-	n.FromBig(x)
+	err = n.FromBig(x)
+	if err != nil {
+		return err
+	}
 	return nil
 
 }
@@ -271,13 +277,20 @@ func (n *U256Str) String() string {
 	return new(big.Int).SetBytes(reverse(n[:])).String()
 }
 
-func (n *U256Str) FromSlice(x []byte) {
+func (n *U256Str) FromSlice(x []byte) error {
+	if len(x) > 32 {
+		return ErrLength
+	}
 	copy(n[:], x)
+	return nil
 }
 
-func (n *U256Str) FromBig(x *big.Int) *U256Str {
+func (n *U256Str) FromBig(x *big.Int) error {
+	if x.BitLen() > 256 {
+		return ErrLength
+	}
 	copy(n[:], reverse(x.FillBytes(n[:])))
-	return n
+	return nil
 }
 
 func IntToU256(i uint64) (ret U256Str) {
@@ -295,9 +308,6 @@ func (e ExtraData) MarshalText() ([]byte, error) {
 func (e *ExtraData) UnmarshalJSON(input []byte) error {
 	var buf = make(hexutil.Bytes, 0)
 	buf.UnmarshalJSON(input)
-	if len(buf) > 32 {
-		return ErrLength
-	}
 	e.FromSlice(buf)
 	return nil
 }
@@ -305,9 +315,6 @@ func (e *ExtraData) UnmarshalJSON(input []byte) error {
 func (e *ExtraData) UnmarshalText(input []byte) error {
 	var buf hexutil.Bytes
 	buf.UnmarshalText(input)
-	if len(buf) > 32 {
-		return ErrLength
-	}
 	e.FromSlice(buf)
 	return nil
 }

--- a/types/common.go
+++ b/types/common.go
@@ -308,6 +308,9 @@ func (e ExtraData) MarshalText() ([]byte, error) {
 func (e *ExtraData) UnmarshalJSON(input []byte) error {
 	var buf = make(hexutil.Bytes, 0)
 	buf.UnmarshalJSON(input)
+	if len(buf) > 32 {
+		return ErrLength
+	}
 	e.FromSlice(buf)
 	return nil
 }
@@ -315,6 +318,9 @@ func (e *ExtraData) UnmarshalJSON(input []byte) error {
 func (e *ExtraData) UnmarshalText(input []byte) error {
 	var buf hexutil.Bytes
 	buf.UnmarshalText(input)
+	if len(buf) > 32 {
+		return ErrLength
+	}
 	e.FromSlice(buf)
 	return nil
 }

--- a/types/common_test.go
+++ b/types/common_test.go
@@ -58,8 +58,9 @@ func TestU256Str(t *testing.T) {
 	u := IntToU256(123)
 	require.Equal(t, "123", u.String())
 
-    value := new(U256Str)
-    err = value.FromBig(big.NewInt(255121513))
+	value := new(U256Str)
+	err = value.FromBig(big.NewInt(255121513))
+	require.NoError(t, err)
 	require.Equal(t, "255121513", value.String())
 }
 
@@ -82,28 +83,28 @@ func TestU256StrCmp(t *testing.T) {
 }
 
 func TestU256StrMaxValue(t *testing.T) {
-    uint256MaxValue, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2**256 - 1
-    uint256MaxValuePlusOne, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639936", 10) // 2**256
+	uint256MaxValue, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)        // 2**256 - 1
+	uint256MaxValuePlusOne, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639936", 10) // 2**256
 
-    value := new(U256Str)
+	value := new(U256Str)
 
-    err := value.FromBig(uint256MaxValue)
-    require.NoError(t, err)
-    err = value.FromBig(uint256MaxValuePlusOne)
-    require.EqualError(t, err, "incorrect byte length")
+	err := value.FromBig(uint256MaxValue)
+	require.NoError(t, err)
+	err = value.FromBig(uint256MaxValuePlusOne)
+	require.EqualError(t, err, "incorrect byte length")
 
-    err = value.UnmarshalText([]byte(uint256MaxValue.String()))
-    require.NoError(t, err)
-    err = value.UnmarshalText([]byte(uint256MaxValuePlusOne.String()))
-    require.EqualError(t, err, "incorrect byte length")
+	err = value.UnmarshalText([]byte(uint256MaxValue.String()))
+	require.NoError(t, err)
+	err = value.UnmarshalText([]byte(uint256MaxValuePlusOne.String()))
+	require.EqualError(t, err, "incorrect byte length")
 
-    err = value.UnmarshalJSON([]byte("\"" + uint256MaxValue.String() + "\""))
-    require.NoError(t, err)
-    err = value.UnmarshalJSON([]byte("\"" + uint256MaxValuePlusOne.String() + "\""))
-    require.EqualError(t, err, "incorrect byte length")
+	err = value.UnmarshalJSON([]byte("\"" + uint256MaxValue.String() + "\""))
+	require.NoError(t, err)
+	err = value.UnmarshalJSON([]byte("\"" + uint256MaxValuePlusOne.String() + "\""))
+	require.EqualError(t, err, "incorrect byte length")
 
-    err = value.FromSlice(make([]byte, 32))
-    require.NoError(t, err)
-    err = value.FromSlice(make([]byte, 33))
-    require.EqualError(t, err, "incorrect byte length")
+	err = value.FromSlice(make([]byte, 32))
+	require.NoError(t, err)
+	err = value.FromSlice(make([]byte, 33))
+	require.EqualError(t, err, "incorrect byte length")
 }

--- a/types/common_test.go
+++ b/types/common_test.go
@@ -58,7 +58,9 @@ func TestU256Str(t *testing.T) {
 	u := IntToU256(123)
 	require.Equal(t, "123", u.String())
 
-	require.Equal(t, "255121513", new(U256Str).FromBig(big.NewInt(255121513)).String())
+    value := new(U256Str)
+    err = value.FromBig(big.NewInt(255121513))
+	require.Equal(t, "255121513", value.String())
 }
 
 func TestU256StrCmp(t *testing.T) {
@@ -77,4 +79,31 @@ func TestU256StrCmp(t *testing.T) {
 
 	require.Equal(t, 1, bigger.Cmp(&two))
 	require.Equal(t, 1, bigger.Cmp(&one))
+}
+
+func TestU256StrMaxValue(t *testing.T) {
+    uint256MaxValue, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10) // 2**256 - 1
+    uint256MaxValuePlusOne, _ := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639936", 10) // 2**256
+
+    value := new(U256Str)
+
+    err := value.FromBig(uint256MaxValue)
+    require.NoError(t, err)
+    err = value.FromBig(uint256MaxValuePlusOne)
+    require.EqualError(t, err, "incorrect byte length")
+
+    err = value.UnmarshalText([]byte(uint256MaxValue.String()))
+    require.NoError(t, err)
+    err = value.UnmarshalText([]byte(uint256MaxValuePlusOne.String()))
+    require.EqualError(t, err, "incorrect byte length")
+
+    err = value.UnmarshalJSON([]byte("\"" + uint256MaxValue.String() + "\""))
+    require.NoError(t, err)
+    err = value.UnmarshalJSON([]byte("\"" + uint256MaxValuePlusOne.String() + "\""))
+    require.EqualError(t, err, "incorrect byte length")
+
+    err = value.FromSlice(make([]byte, 32))
+    require.NoError(t, err)
+    err = value.FromSlice(make([]byte, 33))
+    require.EqualError(t, err, "incorrect byte length")
 }


### PR DESCRIPTION
## 📝 Summary

* Throw an error if the input to `U256Str` "constructors" is invalid:
  * Specifically, if the value is greater than 32 bytes.

## ⛱ Motivation and Context

It would panic if given an invalid value. Thanks to Antonio Sanso for pointing this out.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
