### PR TITLE
Signature add membership check

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -90,7 +90,7 @@ func SignatureFromBytes(sigBytes []byte) (*Signature, error) {
 }
 
 func VerifySignature(sig *Signature, pk *PublicKey, msg []byte) bool {
-	return sig.Verify(false, pk, false, msg, dst)
+	return sig.Verify(true, pk, false, msg, dst)
 }
 
 func VerifySignatureBytes(msg, sigBytes, pkBytes []byte) (bool, error) {


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Sets `sigGroupCheck` to `true`.
## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Membership check for signatures was skipped, which should be required according to the [IETF BLS Signature specification](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#section-5.3). This will enforce the unforgeability of signatures.
## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
