### PR TITLE
Add more length checks to common types

### DIFF
--- a/types/common.go
+++ b/types/common.go
@@ -23,11 +23,7 @@ func (s *Signature) UnmarshalJSON(input []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(b) != 96 {
-		return ErrLength
-	}
-	s.FromSlice(b)
-	return nil
+	return s.FromSlice(b)
 }
 
 func (s *Signature) UnmarshalText(input []byte) error {
@@ -36,20 +32,19 @@ func (s *Signature) UnmarshalText(input []byte) error {
 	if err != nil {
 		return err
 	}
-	if len(b) != 96 {
-		return ErrLength
-	}
-	s.FromSlice(b)
-	return nil
-
+	return s.FromSlice(b)
 }
 
 func (s Signature) String() string {
 	return hexutil.Bytes(s[:]).String()
 }
 
-func (s *Signature) FromSlice(x []byte) {
+func (s *Signature) FromSlice(x []byte) error {
+	if len(x) != 96 {
+		return ErrLength
+	}
 	copy(s[:], x)
+	return nil
 }
 
 type PublicKey [48]byte
@@ -61,30 +56,25 @@ func (p PublicKey) MarshalText() ([]byte, error) {
 func (p *PublicKey) UnmarshalJSON(input []byte) error {
 	b := hexutil.Bytes(p[:])
 	b.UnmarshalJSON(input)
-	if len(b) != 48 {
-		return ErrLength
-	}
-	p.FromSlice(b)
-	return nil
+	return p.FromSlice(b)
 }
 
 func (p *PublicKey) UnmarshalText(input []byte) error {
 	b := hexutil.Bytes(p[:])
 	b.UnmarshalText(input)
-	if len(b) != 48 {
-		return ErrLength
-	}
-	p.FromSlice(b)
-	return nil
-
+	return p.FromSlice(b)
 }
 
 func (p PublicKey) String() string {
 	return hexutil.Bytes(p[:]).String()
 }
 
-func (p *PublicKey) FromSlice(x []byte) {
+func (p *PublicKey) FromSlice(x []byte) error {
+	if len(x) != 48 {
+		return ErrLength
+	}
 	copy(p[:], x)
+	return nil
 }
 
 type Address [20]byte
@@ -96,30 +86,25 @@ func (a Address) MarshalText() ([]byte, error) {
 func (a *Address) UnmarshalJSON(input []byte) error {
 	b := hexutil.Bytes(a[:])
 	b.UnmarshalJSON(input)
-	if len(b) != 20 {
-		return ErrLength
-	}
-	a.FromSlice(b)
-	return nil
+	return a.FromSlice(b)
 }
 
 func (a *Address) UnmarshalText(input []byte) error {
 	b := hexutil.Bytes(a[:])
 	b.UnmarshalText(input)
-	if len(b) != 20 {
-		return ErrLength
-	}
-	a.FromSlice(b)
-	return nil
-
+	return a.FromSlice(b)
 }
 
 func (a Address) String() string {
 	return hexutil.Bytes(a[:]).String()
 }
 
-func (a *Address) FromSlice(x []byte) {
+func (a *Address) FromSlice(x []byte) error {
+	if len(x) != 20 {
+		return ErrLength
+	}
 	copy(a[:], x)
+	return nil
 }
 
 type Hash [32]byte
@@ -132,26 +117,21 @@ func (h Hash) MarshalText() ([]byte, error) {
 func (h *Hash) UnmarshalJSON(input []byte) error {
 	b := hexutil.Bytes(h[:])
 	b.UnmarshalJSON(input)
-	if len(b) != 32 {
-		return ErrLength
-	}
-	h.FromSlice(b)
-	return nil
+	return h.FromSlice(b)
 }
 
 func (h *Hash) UnmarshalText(input []byte) error {
 	b := hexutil.Bytes(h[:])
 	b.UnmarshalText(input)
-	if len(b) != 32 {
-		return ErrLength
-	}
-	h.FromSlice(b)
-	return nil
-
+	return h.FromSlice(b)
 }
 
-func (h *Hash) FromSlice(x []byte) {
+func (h *Hash) FromSlice(x []byte) error {
+	if len(x) != 32 {
+		return ErrLength
+	}
 	copy(h[:], x)
+	return nil
 }
 
 func (h Hash) String() string {
@@ -167,21 +147,13 @@ func (c CommitteeBits) MarshalText() ([]byte, error) {
 func (c *CommitteeBits) UnmarshalJSON(input []byte) error {
 	b := hexutil.Bytes(c[:])
 	b.UnmarshalJSON(input)
-	if len(b) != 64 {
-		return ErrLength
-	}
-	c.FromSlice(b)
-	return nil
+	return c.FromSlice(b)
 }
 
 func (c *CommitteeBits) UnmarshalText(input []byte) error {
 	b := hexutil.Bytes(c[:])
 	b.UnmarshalText(input)
-	if len(b) != 64 {
-		return ErrLength
-	}
-	c.FromSlice(b)
-	return nil
+	return c.FromSlice(b)
 
 }
 
@@ -189,8 +161,12 @@ func (c CommitteeBits) String() string {
 	return hexutil.Bytes(c[:]).String()
 }
 
-func (c *CommitteeBits) FromSlice(x []byte) {
+func (c *CommitteeBits) FromSlice(x []byte) error {
+	if len(x) != 64 {
+		return ErrLength
+	}
 	copy(c[:], x)
+	return nil
 }
 
 type Bloom [256]byte
@@ -202,29 +178,25 @@ func (b Bloom) MarshalText() ([]byte, error) {
 func (b *Bloom) UnmarshalJSON(input []byte) error {
 	buf := hexutil.Bytes(b[:])
 	buf.UnmarshalJSON(input)
-	if len(b) != 256 {
-		return ErrLength
-	}
-	b.FromSlice(buf)
-	return nil
+	return b.FromSlice(buf)
 }
 
 func (b *Bloom) UnmarshalText(input []byte) error {
 	buf := hexutil.Bytes(b[:])
 	buf.UnmarshalText(input)
-	if len(b) != 256 {
-		return ErrLength
-	}
-	b.FromSlice(buf)
-	return nil
+	return b.FromSlice(buf)
 }
 
 func (b Bloom) String() string {
 	return hexutil.Bytes(b[:]).String()
 }
 
-func (b *Bloom) FromSlice(x []byte) {
+func (b *Bloom) FromSlice(x []byte) error {
+	if len(b) != 256 {
+		return ErrLength
+	}
 	copy(b[:], x)
+	return nil
 }
 
 type U256Str Hash // encodes/decodes to string, not hex
@@ -252,11 +224,7 @@ func (n *U256Str) UnmarshalJSON(input []byte) error {
 	if err != nil {
 		return err
 	}
-	err = n.FromBig(x)
-	if err != nil {
-		return err
-	}
-	return nil
+	return n.FromBig(x)
 }
 
 func (n *U256Str) UnmarshalText(input []byte) error {
@@ -265,12 +233,7 @@ func (n *U256Str) UnmarshalText(input []byte) error {
 	if err != nil {
 		return err
 	}
-	err = n.FromBig(x)
-	if err != nil {
-		return err
-	}
-	return nil
-
+	return n.FromBig(x)
 }
 
 func (n *U256Str) String() string {
@@ -306,31 +269,27 @@ func (e ExtraData) MarshalText() ([]byte, error) {
 }
 
 func (e *ExtraData) UnmarshalJSON(input []byte) error {
-	var buf = make(hexutil.Bytes, 0)
+	var buf hexutil.Bytes
 	buf.UnmarshalJSON(input)
-	if len(buf) > 32 {
-		return ErrLength
-	}
-	e.FromSlice(buf)
-	return nil
+	return e.FromSlice(buf)
 }
 
 func (e *ExtraData) UnmarshalText(input []byte) error {
 	var buf hexutil.Bytes
 	buf.UnmarshalText(input)
-	if len(buf) > 32 {
-		return ErrLength
-	}
-	e.FromSlice(buf)
-	return nil
+	return e.FromSlice(buf)
 }
 
 func (e ExtraData) String() string {
 	return hexutil.Bytes(e).String()
 }
 
-func (e *ExtraData) FromSlice(x []byte) {
+func (e *ExtraData) FromSlice(x []byte) error {
+	if len(x) > 32 {
+		return ErrLength
+	}
 	tmp := make([]byte, len(x))
 	copy(tmp, x)
 	*e = tmp
+	return nil
 }


### PR DESCRIPTION
## 📝 Summary

Associated with yesterday's changes to `U256Str`...

* Move length check from marshaling funcs to shared `FromSlice` func.
  * The `FromSlice` funcs were missing length checks.
  * `UnmarshalJSON` and `UnmarshalText` will call `FromSlice`.
* Change `ExtraData` local variable declaration in:
  * `var buf = make(hexutil.Bytes, 0)` -> `var buf hexutil.Bytes`
  * I'm pretty sure these can be swapped, right?
  * This is what `UnmarshalText` uses.

## ⛱ Motivation and Context

Should make things a little safer.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
