### PR TITLE
Add golangci-lint to checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@latest
+
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.1
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
       - name: Lint
         run: make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,69 @@
+linters:
+  enable-all: true
+  disable:
+    - cyclop
+    - exhaustruct
+    - forbidigo
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocritic
+    - godot
+    - godox
+    - gomnd
+    - lll
+    - nestif
+    - nilnil
+    - nlreturn
+    - noctx
+    - nonamedreturns
+    - nosnakecase
+    - paralleltest
+    - revive
+    - testpackage
+    - unparam
+    - varnamelen
+    - wrapcheck
+    - wsl
+
+    #
+    # To fix:
+    #
+    - errcheck
+    - gci
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goimports
+    - thelper
+    - unconvert
+    - whitespace
+
+    #
+    # Disabled because of generics:
+    #
+    - contextcheck
+    - rowserrcheck
+    - sqlclosecheck
+    - structcheck
+    - wastedassign
+
+    #
+    # Disabled because deprecated:
+    #
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
+    - scopelint
+    - varcheck
+
+linters-settings:
+  tagliatelle:
+    case:
+      rules:
+        json: snake
+  gofumpt:
+    extra-rules: true

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,11 @@ fuzz:
 	./scripts/fuzz.sh
 
 lint:
-	gofmt -d ./
+	gofmt -d -s .
+	gofumpt -d -extra .
 	go vet ./...
 	staticcheck ./...
+	golangci-lint run
 
 generate-ssz:
 	rm -f types/builder_encoding.go types/signing_encoding.go types/common_encoding.go

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -11,13 +11,17 @@ import (
 
 var dst = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
 
-const BLSPublicKeyLength int = 48
-const BLSSecretKeyLength int = 32
-const BLSSignatureLength int = 96
+const (
+	BLSPublicKeyLength int = 48
+	BLSSecretKeyLength int = 32
+	BLSSignatureLength int = 96
+)
 
-type PublicKey = blst.P1Affine
-type SecretKey = blst.SecretKey
-type Signature = blst.P2Affine
+type (
+	PublicKey = blst.P1Affine
+	SecretKey = blst.SecretKey
+	Signature = blst.P2Affine
+)
 
 func PublicKeyFromBytes(pkBytes []byte) (*PublicKey, error) {
 	if len(pkBytes) != BLSPublicKeyLength {

--- a/types/common.go
+++ b/types/common.go
@@ -10,9 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-var (
-	ErrLength = fmt.Errorf("incorrect byte length")
-)
+var ErrLength = fmt.Errorf("incorrect byte length")
 
 type Uint64StringSlice []uint64
 
@@ -153,8 +151,10 @@ func (a *Address) FromSlice(x []byte) error {
 	return nil
 }
 
-type Hash [32]byte
-type Root = Hash
+type (
+	Hash [32]byte
+	Root = Hash
+)
 
 func (h Hash) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(h[:]).MarshalText()
@@ -208,7 +208,6 @@ func (c *CommitteeBits) UnmarshalText(input []byte) error {
 		return err
 	}
 	return c.FromSlice(b)
-
 }
 
 func (c CommitteeBits) String() string {

--- a/types/signing.go
+++ b/types/signing.go
@@ -4,9 +4,11 @@ import (
 	"github.com/flashbots/go-boost-utils/bls"
 )
 
-type Domain [32]byte
-type DomainType [4]byte
-type ForkVersion [4]byte
+type (
+	Domain      [32]byte
+	DomainType  [4]byte
+	ForkVersion [4]byte
+)
 
 var (
 	DomainBuilder Domain

--- a/types/signing_test.go
+++ b/types/signing_test.go
@@ -115,7 +115,7 @@ func TestComputeDomainVector(t *testing.T) {
 	}
 }
 
-func _ComputeDomain(domainType DomainType, forkVersionHex string, genesisValidatorsRootHex string) (domain Domain, err error) {
+func _ComputeDomain(domainType DomainType, forkVersionHex, genesisValidatorsRootHex string) (domain Domain, err error) {
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
 	if err != nil || len(forkVersionBytes) > 4 {
 		err = errors.New("invalid fork version passed")
@@ -198,7 +198,7 @@ func TestKilnSignedBlindedBeaconBlockSignature2(t *testing.T) {
 	}
 
 	payload.Message.Body.Deposits = []*Deposit{
-		&Deposit{
+		{
 			Proof: proof,
 			Data: &DepositData{
 				Pubkey:                PublicKey{0x02},


### PR DESCRIPTION
## 📝 Summary

* Add golangci-lint to the lint checks.
  * Also run it in the GitHub CI checks. 
* Enable the "simplify code option" to gofmt.
* Add gofumpt (a slightly better gofmt) to the checks.
  * Fix it's findings.
* Temporarily disable all of the rules with findings.
  * I will fix these in subsequent PRs.

## ⛱ Motivation and Context

I think we should enable golangci-lint. This will run a collection of lint checks. We use this in the relay.

## 📚 References

* https://golangci-lint.run
* https://github.com/mvdan/gofumpt

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
