### PR TITLE
Fix findings from several linters

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -19,18 +19,29 @@ type PublicKey = blst.P1Affine
 type SecretKey = blst.SecretKey
 type Signature = blst.P2Affine
 
+var (
+	ErrDeserializeSecretKey   = errors.New("could not deserialize secret key from bytes")
+	ErrInvalidPubkey          = errors.New("invalid pubkey")
+	ErrInvalidPubkeyLength    = errors.New("invalid pubkey length")
+	ErrInvalidSecretKeyLength = errors.New("invalid secret key length")
+	ErrInvalidSignature       = errors.New("invalid signature")
+	ErrInvalidSignatureLength = errors.New("invalid signature length")
+	ErrUncompressPubkey       = errors.New("could not uncompress public key from bytes")
+	ErrUncompressSignature    = errors.New("could not uncompress signature from bytes")
+)
+
 func PublicKeyFromBytes(pkBytes []byte) (*PublicKey, error) {
 	if len(pkBytes) != BLSPublicKeyLength {
-		return nil, errors.New("invalid pubkey length")
+		return nil, ErrInvalidPubkeyLength
 	}
 
 	pk := new(PublicKey).Uncompress(pkBytes)
 	if pk == nil {
-		return nil, errors.New("could not uncompress public key from bytes")
+		return nil, ErrUncompressPubkey
 	}
 
 	if !pk.KeyValidate() {
-		return nil, errors.New("invalid pubkey")
+		return nil, ErrInvalidPubkey
 	}
 
 	return pk, nil
@@ -42,11 +53,11 @@ func PublicKeyFromSecretKey(sk *SecretKey) *PublicKey {
 
 func SecretKeyFromBytes(skBytes []byte) (*SecretKey, error) {
 	if len(skBytes) != BLSSecretKeyLength {
-		return nil, errors.New("invalid secret key length")
+		return nil, ErrInvalidSecretKeyLength
 	}
 	secretKey := new(SecretKey).Deserialize(skBytes)
 	if secretKey == nil {
-		return nil, errors.New("could not deserialize secret key from bytes")
+		return nil, ErrDeserializeSecretKey
 	}
 	return secretKey, nil
 }
@@ -75,16 +86,16 @@ func Sign(sk *SecretKey, msg []byte) *Signature {
 
 func SignatureFromBytes(sigBytes []byte) (*Signature, error) {
 	if len(sigBytes) != BLSSignatureLength {
-		return nil, errors.New("invalid signature length")
+		return nil, ErrInvalidSignatureLength
 	}
 
 	sig := new(Signature).Uncompress(sigBytes)
 	if sig == nil {
-		return nil, errors.New("could not uncompress signature from bytes")
+		return nil, ErrUncompressSignature
 	}
 
 	if !sig.SigValidate(false) {
-		return nil, errors.New("invalid signature")
+		return nil, ErrInvalidSignature
 	}
 	return sig, nil
 }

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trailofbits/go-fuzz-utils"
+	go_fuzz_utils "github.com/trailofbits/go-fuzz-utils"
 )
 
 func GetTypeProvider(data []byte) (*go_fuzz_utils.TypeProvider, error) {

--- a/types/builder.go
+++ b/types/builder.go
@@ -16,6 +16,8 @@ import (
 // TODO: figure out why sszgen puts hexutil in code gen despite it not being used
 // TODO: figure out why sszgen doesn't handle import of []byte correctly and tries to create ssz methods for it
 
+var ErrNilPayload = errors.New("nil payload")
+
 // Eth1Data https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#eth1data
 type Eth1Data struct {
 	DepositRoot  Root   `json:"deposit_root" ssz-size:"32"`
@@ -289,12 +291,12 @@ type BuilderSubmitBlockResponse struct {
 // PayloadToPayloadHeader converts an ExecutionPayload to ExecutionPayloadHeader
 func PayloadToPayloadHeader(p *ExecutionPayload) (*ExecutionPayloadHeader, error) {
 	if p == nil {
-		return nil, errors.New("nil payload")
+		return nil, ErrNilPayload
 	}
 
 	txs := [][]byte{}
 	for _, tx := range p.Transactions {
-		txs = append(txs, []byte(tx))
+		txs = append(txs, tx)
 	}
 
 	transactions := Transactions{Transactions: txs}
@@ -317,6 +319,6 @@ func PayloadToPayloadHeader(p *ExecutionPayload) (*ExecutionPayloadHeader, error
 		ExtraData:        ExtraData(p.ExtraData),
 		BaseFeePerGas:    p.BaseFeePerGas,
 		BlockHash:        p.BlockHash,
-		TransactionsRoot: [32]byte(txroot),
+		TransactionsRoot: txroot,
 	}, nil
 }

--- a/types/common.go
+++ b/types/common.go
@@ -208,7 +208,6 @@ func (c *CommitteeBits) UnmarshalText(input []byte) error {
 		return err
 	}
 	return c.FromSlice(b)
-
 }
 
 func (c CommitteeBits) String() string {

--- a/types/common_fuzz_test.go
+++ b/types/common_fuzz_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trailofbits/go-fuzz-utils"
+	go_fuzz_utils "github.com/trailofbits/go-fuzz-utils"
 )
 
 func GetTypeProvider(data []byte) (*go_fuzz_utils.TypeProvider, error) {
@@ -44,6 +44,7 @@ type MarshalableSSZ interface {
 }
 
 func RoundTripSSZ[V MarshalableSSZ](t *testing.T, data []byte, decSSZ V) {
+	t.Helper()
 	value := *new(V)
 	if !Fill(data, &value) {
 		return
@@ -81,6 +82,7 @@ func RoundTripSSZ[V MarshalableSSZ](t *testing.T, data []byte, decSSZ V) {
 }
 
 func RoundTripJSON[V any](t *testing.T, data []byte, decJSON V) {
+	t.Helper()
 	value := *new(V)
 	if !Fill(data, &value) {
 		return

--- a/types/signing_test.go
+++ b/types/signing_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/stretchr/testify/require"
-
 	"github.com/flashbots/go-boost-utils/bls"
+	"github.com/stretchr/testify/require"
 )
+
+var ErrInvalidForkVersion = errors.New("invalid fork version passed")
 
 func TestVerifySignature(t *testing.T) {
 	sk, pk, err := bls.GenerateNewKeypair()
@@ -118,8 +119,7 @@ func TestComputeDomainVector(t *testing.T) {
 func _ComputeDomain(domainType DomainType, forkVersionHex string, genesisValidatorsRootHex string) (domain Domain, err error) {
 	forkVersionBytes, err := hexutil.Decode(forkVersionHex)
 	if err != nil || len(forkVersionBytes) > 4 {
-		err = errors.New("invalid fork version passed")
-		return domain, err
+		return domain, ErrInvalidForkVersion
 	}
 	var forkVersion [4]byte
 	copy(forkVersion[:], forkVersionBytes[:4])


### PR DESCRIPTION
## 📝 Summary

Fixes the findings from these golangci-lint checks:

* gci
* goerr113
* goimports
* thelper
* unconvert
* whitespace

Just need to fix errcheck findings now. I think that deserves its own PR.

## ⛱ Motivation and Context

Associated with #45, fixes most of the problems.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
