### PR TITLE
Handle all errors

### DIFF
--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -29,7 +29,7 @@ func GetTypeProvider(data []byte) (*go_fuzz_utils.TypeProvider, error) {
 
 func FuzzPublicKeyFromBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		PublicKeyFromBytes(data)
+		_, _ = PublicKeyFromBytes(data)
 	})
 }
 
@@ -43,7 +43,7 @@ func FuzzPublicKeyFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		PublicKeyFromBytes(bytes)
+		_, _ = PublicKeyFromBytes(bytes)
 	})
 }
 
@@ -65,7 +65,7 @@ func FuzzPublicKeyFromSecretKey(f *testing.F) {
 
 func FuzzSecretKeyFromBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		SecretKeyFromBytes(data)
+		_, _ = SecretKeyFromBytes(data)
 	})
 }
 
@@ -79,13 +79,13 @@ func FuzzSecretKeyFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		SecretKeyFromBytes(bytes)
+		_, _ = SecretKeyFromBytes(bytes)
 	})
 }
 
 func FuzzSignatureFromBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		SignatureFromBytes(data)
+		_, _ = SignatureFromBytes(data)
 	})
 }
 
@@ -99,7 +99,7 @@ func FuzzSignatureFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		SignatureFromBytes(bytes)
+		_, _ = SignatureFromBytes(bytes)
 	})
 }
 
@@ -142,7 +142,7 @@ func FuzzVerifySignature(f *testing.F) {
 		if err != nil {
 			return
 		}
-		VerifySignature(&sig, &pk, msg)
+		_ = VerifySignature(&sig, &pk, msg)
 	})
 }
 
@@ -164,7 +164,7 @@ func FuzzVerifySignatureBytes(f *testing.F) {
 		if err != nil {
 			return
 		}
-		VerifySignatureBytes(msg, sigBytes, pkBytes)
+		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
 	})
 }
 
@@ -186,6 +186,6 @@ func FuzzVerifySignatureBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		VerifySignatureBytes(msg, sigBytes, pkBytes)
+		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
 	})
 }

--- a/types/builder_fuzz_test.go
+++ b/types/builder_fuzz_test.go
@@ -15,8 +15,8 @@ func FuzzRoundTripEth1Data(f *testing.F) {
 func FuzzUnmarshalEth1Data(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Eth1Data
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -30,8 +30,8 @@ func FuzzRoundTripBeaconBlockHeader(f *testing.F) {
 func FuzzUnmarshalBeaconBlockHeader(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BeaconBlockHeader
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -45,8 +45,8 @@ func FuzzRoundTripSignedBeaconBlockHeader(f *testing.F) {
 func FuzzUnmarshalSignedBeaconBlockHeader(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SignedBeaconBlockHeader
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -60,8 +60,8 @@ func FuzzRoundTripProposerSlashing(f *testing.F) {
 func FuzzUnmarshalProposerSlashing(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value ProposerSlashing
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -75,8 +75,8 @@ func FuzzRoundTripCheckpoint(f *testing.F) {
 func FuzzUnmarshalCheckpoint(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Checkpoint
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -90,8 +90,8 @@ func FuzzRoundTripAttestationData(f *testing.F) {
 func FuzzUnmarshalAttestationData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value AttestationData
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -105,8 +105,8 @@ func FuzzRoundTripIndexedAttestation(f *testing.F) {
 func FuzzUnmarshalIndexedAttestation(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value IndexedAttestation
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -120,8 +120,8 @@ func FuzzRoundTripAttesterSlashing(f *testing.F) {
 func FuzzUnmarshalAttesterSlashing(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value AttesterSlashing
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -135,8 +135,8 @@ func FuzzRoundTripAttestation(f *testing.F) {
 func FuzzUnmarshalAttestation(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Attestation
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -150,8 +150,8 @@ func FuzzRoundTripDeposit(f *testing.F) {
 func FuzzUnmarshalDeposit(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Deposit
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -165,8 +165,8 @@ func FuzzRoundTripSyncAggregate(f *testing.F) {
 func FuzzUnmarshalSyncAggregate(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SyncAggregate
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -180,8 +180,8 @@ func FuzzRoundTripVoluntaryExit(f *testing.F) {
 func FuzzUnmarshalVoluntaryExit(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value VoluntaryExit
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -195,8 +195,8 @@ func FuzzRoundTripExecutionPayloadHeader(f *testing.F) {
 func FuzzUnmarshalExecutionPayloadHeader(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value ExecutionPayloadHeader
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -209,7 +209,7 @@ func FuzzRoundTripExecutionPayload(f *testing.F) {
 func FuzzUnmarshalExecutionPayload(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value ExecutionPayload
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -223,8 +223,8 @@ func FuzzRoundTripBlindedBeaconBlockBody(f *testing.F) {
 func FuzzUnmarshalBlindedBeaconBlockBody(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BlindedBeaconBlockBody
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -237,7 +237,7 @@ func FuzzRoundTripBeaconBlockBody(f *testing.F) {
 func FuzzUnmarshalBeaconBlockBody(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BeaconBlockBody
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -251,8 +251,8 @@ func FuzzRoundTripBlindedBeaconBlock(f *testing.F) {
 func FuzzUnmarshalBlindedBeaconBlock(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BlindedBeaconBlock
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -265,7 +265,7 @@ func FuzzRoundTripBeaconBlock(f *testing.F) {
 func FuzzUnmarshalBeaconBlock(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BeaconBlock
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -279,8 +279,8 @@ func FuzzRoundTripRegisterValidatorRequestMessage(f *testing.F) {
 func FuzzUnmarshalRegisterValidatorRequestMessage(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value RegisterValidatorRequestMessage
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -293,7 +293,7 @@ func FuzzRoundTripSignedValidatorRegistration(f *testing.F) {
 func FuzzUnmarshalSignedValidatorRegistration(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SignedValidatorRegistration
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -307,8 +307,8 @@ func FuzzRoundTripBuilderBid(f *testing.F) {
 func FuzzUnmarshalBuilderBid(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BuilderBid
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -322,8 +322,8 @@ func FuzzRoundTripSignedBuilderBid(f *testing.F) {
 func FuzzUnmarshalSignedBuilderBid(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SignedBuilderBid
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -336,7 +336,7 @@ func FuzzRoundTripGetHeaderResponse(f *testing.F) {
 func FuzzUnmarshalGetHeaderResponse(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value GetHeaderResponse
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -349,7 +349,7 @@ func FuzzRoundTripSignedBlindedBeaconBlock(f *testing.F) {
 func FuzzUnmarshalSignedBlindedBeaconBlock(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SignedBlindedBeaconBlock
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -362,7 +362,7 @@ func FuzzRoundTripGetPayloadResponse(f *testing.F) {
 func FuzzUnmarshalGetPayloadResponse(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value GetPayloadResponse
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -376,8 +376,8 @@ func FuzzRoundTripTransactions(f *testing.F) {
 func FuzzUnmarshalTransactions(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Transactions
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -390,7 +390,7 @@ func FuzzRoundTripBuilderGetValidatorsResponseEntry(f *testing.F) {
 func FuzzUnmarshalBuilderGetValidatorsResponseEntry(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BuilderGetValidatorsResponseEntry
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -404,8 +404,8 @@ func FuzzRoundTripBidTrace(f *testing.F) {
 func FuzzUnmarshalBidTrace(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BidTrace
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -418,7 +418,7 @@ func FuzzRoundTripSignedBidTrace(f *testing.F) {
 func FuzzUnmarshalSignedBidTrace(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SignedBidTrace
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -431,7 +431,7 @@ func FuzzRoundTripBuilderSubmitBlockRequest(f *testing.F) {
 func FuzzUnmarshalBuilderSubmitBlockRequest(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BuilderSubmitBlockRequest
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -445,8 +445,8 @@ func FuzzRoundTripBuilderSubmitBlockResponseMessage(f *testing.F) {
 func FuzzUnmarshalBuilderSubmitBlockResponseMessage(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BuilderSubmitBlockResponseMessage
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -459,7 +459,7 @@ func FuzzRoundTripBuilderSubmitBlockResponse(f *testing.F) {
 func FuzzUnmarshalBuilderSubmitBlockResponse(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value BuilderSubmitBlockResponse
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -469,6 +469,6 @@ func FuzzPayloadToPayloadHeader(f *testing.F) {
 		if !Fill(data, &payloadHeader) {
 			return
 		}
-		PayloadToPayloadHeader(&payloadHeader)
+		_, _ = PayloadToPayloadHeader(&payloadHeader)
 	})
 }

--- a/types/common_fuzz_test.go
+++ b/types/common_fuzz_test.go
@@ -115,7 +115,7 @@ func FuzzRoundTripUint64StringSlice(f *testing.F) {
 func FuzzUnmarshalUint64StringSlice(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Uint64StringSlice
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
@@ -128,13 +128,13 @@ func FuzzRoundTripSignature(f *testing.F) {
 func FuzzUnmarshalSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Signature
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(Signature).FromSlice(data)
+		_ = new(Signature).FromSlice(data)
 	})
 }
 
@@ -147,13 +147,13 @@ func FuzzRoundTripPublicKey(f *testing.F) {
 func FuzzUnmarshalPublicKey(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value PublicKey
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSlicePublicKey(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(PublicKey).FromSlice(data)
+		_ = new(PublicKey).FromSlice(data)
 	})
 }
 
@@ -166,13 +166,13 @@ func FuzzRoundTripAddress(f *testing.F) {
 func FuzzUnmarshalAddress(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Address
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceAddress(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(Address).FromSlice(data)
+		_ = new(Address).FromSlice(data)
 	})
 }
 
@@ -185,13 +185,13 @@ func FuzzRoundTripHash(f *testing.F) {
 func FuzzUnmarshalHash(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Hash
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceHash(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(Hash).FromSlice(data)
+		_ = new(Hash).FromSlice(data)
 	})
 }
 
@@ -204,13 +204,13 @@ func FuzzRoundTripRoot(f *testing.F) {
 func FuzzUnmarshalRoot(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Root
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceRoot(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(Root).FromSlice(data)
+		_ = new(Root).FromSlice(data)
 	})
 }
 
@@ -223,13 +223,13 @@ func FuzzRoundTripCommitteeBits(f *testing.F) {
 func FuzzUnmarshalCommitteeBits(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value CommitteeBits
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceCommitteeBits(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(CommitteeBits).FromSlice(data)
+		_ = new(CommitteeBits).FromSlice(data)
 	})
 }
 
@@ -242,13 +242,13 @@ func FuzzRoundTripBloom(f *testing.F) {
 func FuzzUnmarshalBloom(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value Bloom
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceBloom(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(Bloom).FromSlice(data)
+		_ = new(Bloom).FromSlice(data)
 	})
 }
 
@@ -261,13 +261,13 @@ func FuzzRoundTripU256Str(f *testing.F) {
 func FuzzUnmarshalU256Str(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value U256Str
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceU256Str(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(U256Str).FromSlice(data)
+		_ = new(U256Str).FromSlice(data)
 	})
 }
 
@@ -280,12 +280,12 @@ func FuzzRoundTripExtraData(f *testing.F) {
 func FuzzUnmarshalExtraData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value ExtraData
-		json.Unmarshal(data, &value)
+		_ = json.Unmarshal(data, &value)
 	})
 }
 
 func FuzzFromSliceExtraData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		new(ExtraData).FromSlice(data)
+		_ = new(ExtraData).FromSlice(data)
 	})
 }

--- a/types/hashing_test.go
+++ b/types/hashing_test.go
@@ -29,6 +29,7 @@ func TestCalculateHash(t *testing.T) {
 	payload := new(ExecutionPayload)
 	require.NoError(t, DecodeJSON(strings.NewReader(payloadJSON), payload))
 
-	hash := CalculateHash(payload)
+	hash, err := CalculateHash(payload)
+	require.NoError(t, err)
 	require.Equal(t, "0x6662fb418aa7b5c5c80e2e8bc87be48db82e799c4704368d34ddeb3b12549655", hash.String())
 }

--- a/types/signing.go
+++ b/types/signing.go
@@ -69,7 +69,10 @@ func SignMessage(obj HashTreeRoot, d Domain, sk *bls.SecretKey) (Signature, erro
 	signatureBytes := bls.Sign(sk, root[:]).Compress()
 
 	var signature Signature
-	signature.FromSlice(signatureBytes)
+	err = signature.FromSlice(signatureBytes)
+	if err != nil {
+		return [96]byte{}, err
+	}
 
 	return signature, nil
 }

--- a/types/signing_fuzz_test.go
+++ b/types/signing_fuzz_test.go
@@ -17,8 +17,8 @@ func FuzzRoundTripSigningData(f *testing.F) {
 func FuzzUnmarshalSigningData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value SigningData
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -32,8 +32,8 @@ func FuzzRoundTripForkData(f *testing.F) {
 func FuzzUnmarshalForkData(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var value ForkData
-		json.Unmarshal(data, &value)
-		value.UnmarshalSSZ(data)
+		_ = json.Unmarshal(data, &value)
+		_ = value.UnmarshalSSZ(data)
 	})
 }
 
@@ -78,7 +78,7 @@ func FuzzComputeSigningRoot(f *testing.F) {
 		if err != nil {
 			return
 		}
-		ComputeSigningRoot(&forkData, domain)
+		_, _ = ComputeSigningRoot(&forkData, domain)
 	})
 }
 
@@ -108,7 +108,7 @@ func FuzzSignMessage(f *testing.F) {
 		if err != nil {
 			return
 		}
-		SignMessage(&forkData, domain, &sk)
+		_, _ = SignMessage(&forkData, domain, &sk)
 	})
 }
 
@@ -138,6 +138,6 @@ func FuzzVerifySignature(f *testing.F) {
 		if err != nil {
 			return
 		}
-		VerifySignature(&forkData, domain, pkBytes, sigBytes)
+		_, _ = VerifySignature(&forkData, domain, pkBytes, sigBytes)
 	})
 }

--- a/types/signing_test.go
+++ b/types/signing_test.go
@@ -43,7 +43,8 @@ func genValidatorRegistration(t require.TestingT, domain Domain) *SignedValidato
 	require.NoError(t, err)
 
 	var pubKey PublicKey
-	pubKey.FromSlice(pk.Compress())
+	err = pubKey.FromSlice(pk.Compress())
+	require.NoError(t, err)
 
 	msg := &RegisterValidatorRequestMessage{
 		FeeRecipient: Address{0x42},
@@ -89,7 +90,8 @@ func TestVerifySignatureManualPk(t *testing.T) {
 	require.NoError(t, err)
 	sig2 := bls.Sign(sk2, root2[:]).Compress()
 	var signature2 Signature
-	signature2.FromSlice(sig2)
+	err = signature2.FromSlice(sig2)
+	require.NoError(t, err)
 	require.Equal(t, "0x8e09a0ae7af113da2043001cc19fb1b3b24bbe022c1b8050ba2297ad1186f4217dd7095edad1d16d83d10f3297883d9e1674c81da95f10d3358c5afdb2500279e720b32879219c9a3b33415239bf46a66cd92b9d1750a6dd7cc7ec936a357128", signature2.String())
 }
 
@@ -108,7 +110,8 @@ func TestComputeDomainVector(t *testing.T) {
 		{"0x07000000", "0x01000000", "0x0a08c27fe4ece2483f9e581f78c66379a06f96e9c24cd1390594ff939b26f95b", "0x07000000b503183cf3d26841cf4499d79f4387520811f5ed97776f0d5317f086"},
 	} {
 		var genesisValidatorsRoot Root
-		genesisValidatorsRoot.FromSlice(hexutil.MustDecode(tc.GenesisValidatorsRoot))
+		err := genesisValidatorsRoot.FromSlice(hexutil.MustDecode(tc.GenesisValidatorsRoot))
+		require.NoError(t, err)
 		var expectedDomain [32]byte
 		copy(expectedDomain[:], hexutil.MustDecode(tc.ExpectedDomain)[:32])
 		require.Equal(t, expectedDomain, ComputeDomain(bytesTo4(hexutil.MustDecode(tc.DomainType)), bytesTo4(hexutil.MustDecode(tc.ForkVersion)), genesisValidatorsRoot))

--- a/types/utils.go
+++ b/types/utils.go
@@ -26,8 +26,8 @@ func (p PubkeyHex) String() string {
 
 func IntToU256(i uint64) (ret U256Str) {
 	s := fmt.Sprint(i)
-	ret.UnmarshalText([]byte(s))
-	return
+	_ = ret.UnmarshalText([]byte(s))
+	return ret
 }
 
 func (n *U256Str) BigInt() *big.Int {
@@ -42,9 +42,9 @@ func (n *U256Str) Cmp(b *U256Str) int {
 	return _a.Cmp(_b)
 }
 
-func BlsPublicKeyToPublicKey(blsPubKey *bls.PublicKey) (ret PublicKey) {
-	ret.FromSlice(blsPubKey.Compress())
-	return
+func BlsPublicKeyToPublicKey(blsPubKey *bls.PublicKey) (ret PublicKey, err error) {
+	err = ret.FromSlice(blsPubKey.Compress())
+	return ret, err
 }
 
 // HexToAddress takes a hex string and returns an Address

--- a/types/utils_fuzz_test.go
+++ b/types/utils_fuzz_test.go
@@ -15,7 +15,7 @@ func FuzzNewPubkeyHex(f *testing.F) {
 func FuzzIntToU256(f *testing.F) {
 	f.Fuzz(func(t *testing.T, value uint64) {
 		u256 := IntToU256(value)
-		bigInt := (*(&u256).BigInt())
+		bigInt := *(&u256).BigInt()
 		require.True(t, bigInt.IsUint64())
 		require.Equal(t, bigInt.Uint64(), value)
 	})
@@ -43,18 +43,18 @@ func FuzzU256StrCmp(f *testing.F) {
 
 func FuzzHexToAddress(f *testing.F) {
 	f.Fuzz(func(t *testing.T, str string) {
-		HexToAddress(str)
+		_, _ = HexToAddress(str)
 	})
 }
 
 func FuzzHexToPubkey(f *testing.F) {
 	f.Fuzz(func(t *testing.T, str string) {
-		HexToPubkey(str)
+		_, _ = HexToPubkey(str)
 	})
 }
 
 func FuzzHexToSignature(f *testing.F) {
 	f.Fuzz(func(t *testing.T, str string) {
-		HexToSignature(str)
+		_, _ = HexToSignature(str)
 	})
 }


### PR DESCRIPTION
## 📝 Summary

* Ignore return values from fuzzing functions.
  * We don't care if there was an error, we're looking for crashes.
* Handle errors in `ExecutionPayloadToHeader` & `CalculateHash`.
  * Looks like these are used externally, can't update usages.
  * `tx.UnmarshalBinary` can return an error...
* Handle error in `BlsPublicKeyToPublicKey`.
  * I think this is also only used externally, or not at all.

## ⛱ Motivation and Context

Associated with #45 & #46. Fixes the `errcheck` findings.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
