### PR TITLE
Enable golangci checks with no findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,7 @@
 linters:
   enable-all: true
   disable:
-    - cyclop
     - exhaustruct
-    - forbidigo
     - funlen
     - gochecknoglobals
     - gochecknoinits
@@ -12,16 +10,11 @@ linters:
     - godox
     - gomnd
     - lll
-    - nestif
-    - nilnil
     - nlreturn
-    - noctx
     - nonamedreturns
     - nosnakecase
     - paralleltest
-    - revive
     - testpackage
-    - unparam
     - varnamelen
     - wrapcheck
     - wsl

--- a/types/signing.go
+++ b/types/signing.go
@@ -13,8 +13,8 @@ type (
 var (
 	DomainBuilder Domain
 
-	DomainTypeBeaconProposer DomainType = DomainType{0x00, 0x00, 0x00, 0x00}
-	DomainTypeAppBuilder     DomainType = DomainType{0x00, 0x00, 0x00, 0x01}
+	DomainTypeBeaconProposer = DomainType{0x00, 0x00, 0x00, 0x00}
+	DomainTypeAppBuilder     = DomainType{0x00, 0x00, 0x00, 0x01}
 )
 
 func init() {


### PR DESCRIPTION
## 📝 Summary

* Remove checks with no findings from the list of disabled checks.
* The exception is `revive` which only had a very minor fix.

## ⛱ Motivation and Context

I'd like to enable these checks now to prevent problems in the future.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
