### PR TITLE
Add fork choice response from execution client

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,3 +47,9 @@ linters-settings:
         json: snake
   gofumpt:
     extra-rules: true
+
+issues:
+  exclude-rules:
+    path: types/execution.go
+    linters:
+      - tagliatelle

--- a/types/builder.go
+++ b/types/builder.go
@@ -12,19 +12,6 @@ import (
 
 var ErrNilPayload = errors.New("nil payload")
 
-// PayloadStatusV1 https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadstatusv1
-type PayloadStatusV1 struct {
-	Status          string  `json:"status"`
-	LatestValidHash *Hash   `json:"latestValidHash"`
-	ValidationError *string `json:"validationError"`
-}
-
-// ForkChoiceResponse https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#response-1
-type ForkChoiceResponse struct {
-	PayloadStatus PayloadStatusV1 `json:"payloadStatus"`
-	PayloadID     *PayloadID      `json:"payloadId"`
-}
-
 // Eth1Data https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#eth1data
 type Eth1Data struct {
 	DepositRoot  Root   `json:"deposit_root" ssz-size:"32"`

--- a/types/builder_test.go
+++ b/types/builder_test.go
@@ -339,16 +339,3 @@ func TestSignedBlindedBeaconBlockWithDeposit(t *testing.T) {
 	signedBlindedBeaconBlock := new(SignedBlindedBeaconBlock)
 	require.NoError(t, DecodeJSON(jsonFile, &signedBlindedBeaconBlock))
 }
-
-func TestForkChoiceResponse(t *testing.T) {
-	input := `{
-		"payloadStatus": {
-		  "status": "VALID",
-		  "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
-		  "validationError": null
-		},
-		"payloadId": "0xa247243752eb10b4"
-	}`
-	var result ForkChoiceResponse
-	require.NoError(t, DecodeJSON(strings.NewReader(input), &result))
-}

--- a/types/execution.go
+++ b/types/execution.go
@@ -1,0 +1,14 @@
+package types
+
+// PayloadStatusV1 https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#payloadstatusv1
+type PayloadStatusV1 struct {
+	Status          string  `json:"status"`
+	LatestValidHash *Hash   `json:"latestValidHash"`
+	ValidationError *string `json:"validationError"`
+}
+
+// ForkChoiceResponse https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#response-1
+type ForkChoiceResponse struct {
+	PayloadStatus PayloadStatusV1 `json:"payloadStatus"`
+	PayloadID     *PayloadID      `json:"payloadId"`
+}

--- a/types/execution_test.go
+++ b/types/execution_test.go
@@ -1,0 +1,21 @@
+package types
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForkChoiceResponse(t *testing.T) {
+	input := `{
+		"payloadStatus": {
+		  "status": "VALID",
+		  "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
+		  "validationError": null
+		},
+		"payloadId": "0xa247243752eb10b4"
+	}`
+	var result ForkChoiceResponse
+	require.NoError(t, DecodeJSON(strings.NewReader(input), &result))
+}


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

## ⛱ Motivation and Context
This is added to boost-types to move execution client responses to a common util library

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
