### PR TITLE
Check sign of big.Int in u256str.FromBig

### DIFF
--- a/types/common.go
+++ b/types/common.go
@@ -10,7 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-var ErrLength = fmt.Errorf("incorrect byte length")
+var (
+	ErrLength = fmt.Errorf("incorrect byte length")
+	ErrSign   = fmt.Errorf("negative value casted as unsigned int")
+)
 
 type Uint64StringSlice []uint64
 
@@ -308,6 +311,9 @@ func (n *U256Str) FromSlice(x []byte) error {
 func (n *U256Str) FromBig(x *big.Int) error {
 	if x.BitLen() > 256 {
 		return ErrLength
+	}
+	if x.Sign() == -1 {
+		return ErrSign
 	}
 	copy(n[:], reverse(x.FillBytes(n[:])))
 	return nil

--- a/types/common_test.go
+++ b/types/common_test.go
@@ -62,6 +62,9 @@ func TestU256Str(t *testing.T) {
 	err = value.FromBig(big.NewInt(255121513))
 	require.NoError(t, err)
 	require.Equal(t, "255121513", value.String())
+
+	err = value.FromBig(big.NewInt(-50))
+	require.Error(t, ErrSign, err)
 }
 
 func TestU256StrCmp(t *testing.T) {


### PR DESCRIPTION
## 📝 Summary

Check the sign of cased big.Int in u256str.FromBig.

## ⛱ Motivation and Context

Casting of a negative value should result in an error instead of returning an incorrect value.

## 📚 References

https://github.com/flashbots/boost-geth-builder/pull/33/files

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
