### PR TITLE
Replace blst with kilic

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
       - name: Lint
         run: make lint

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,9 +6,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
-      CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -25,9 +22,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
-      CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -42,7 +36,7 @@ jobs:
         run: go install mvdan.cc/gofumpt@latest
 
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.1
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
@@ -56,9 +50,6 @@ jobs:
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
-    env:
-      CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
-      CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -26,7 +26,7 @@ type (
 )
 
 var (
-	ErrInvalidPubkeyLength    = errors.New("invalid pubkey length")
+	ErrInvalidPubkeyLength    = errors.New("invalid public key length")
 	ErrInvalidSecretKeyLength = errors.New("invalid secret key length")
 	ErrInvalidSignatureLength = errors.New("invalid signature length")
 	ErrSecretKeyIsZero        = errors.New("invalid secret key is zero")

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -119,7 +119,7 @@ func VerifySignature(sig *Signature, pk *PublicKey, msg []byte) (bool, error) {
 	return pairingEngine.Check(), nil
 }
 
-func VerifySignatureBytes(msg, sigBytes, pkBytes []byte) (bool, error) {
+func VerifySignatureBytes(sigBytes, pkBytes, msg []byte) (bool, error) {
 	pk, err := PublicKeyFromBytes(pkBytes)
 	if err != nil {
 		return false, err

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -119,7 +119,7 @@ func VerifySignature(sig *Signature, pk *PublicKey, msg []byte) (bool, error) {
 	return pairingEngine.Check(), nil
 }
 
-func VerifySignatureBytes(sigBytes, pkBytes, msg []byte) (bool, error) {
+func VerifySignatureBytes(msg, sigBytes, pkBytes []byte) (bool, error) {
 	pk, err := PublicKeyFromBytes(pkBytes)
 	if err != nil {
 		return false, err

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -28,9 +28,8 @@ type (
 var (
 	ErrInvalidPubkeyLength    = errors.New("invalid pubkey length")
 	ErrInvalidSecretKeyLength = errors.New("invalid secret key length")
-	ErrSecretKeyIsZero        = errors.New("invalid secret key is zero")
 	ErrInvalidSignatureLength = errors.New("invalid signature length")
-	ErrUncompressSignature    = errors.New("could not uncompress signature from bytes")
+	ErrSecretKeyIsZero        = errors.New("invalid secret key is zero")
 )
 
 func PublicKeyToBytes(pk *PublicKey) []byte {
@@ -104,11 +103,7 @@ func SignatureFromBytes(sigBytes []byte) (*Signature, error) {
 	if len(sigBytes) != SignatureLength {
 		return nil, ErrInvalidSignatureLength
 	}
-	sig, err := bls12381.NewG2().FromCompressed(sigBytes)
-	if err != nil {
-		return nil, ErrUncompressSignature
-	}
-	return sig, nil
+	return bls12381.NewG2().FromCompressed(sigBytes)
 }
 
 func VerifySignatureBytes(msg, sigBytes, pkBytes []byte) (bool, error) {

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -114,17 +114,14 @@ func SignatureFromBytes(sigBytes []byte) (*Signature, error) {
 func VerifySignatureBytes(msg, sigBytes, pkBytes []byte) (bool, error) {
 	xP, err := bls12381.NewG1().FromCompressed(pkBytes)
 	if err != nil {
-		panic(err)
 		return false, err
 	}
 	Q, err := bls12381.NewG2().HashToCurve(msg, domain)
 	if err != nil {
-		panic(err)
 		return false, err
 	}
 	R, err := bls12381.NewG2().FromCompressed(sigBytes)
 	if err != nil {
-		panic(err)
 		return false, err
 	}
 	P := &bls12381.G1One

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -166,7 +166,7 @@ func FuzzVerifySignatureBytes(f *testing.F) {
 		if err != nil {
 			return
 		}
-		_, _ = VerifySignatureBytes(sigBytes, pkBytes, msg)
+		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
 	})
 }
 
@@ -188,6 +188,6 @@ func FuzzVerifySignatureBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		_, _ = VerifySignatureBytes(sigBytes, pkBytes, msg)
+		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
 	})
 }

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -124,6 +124,30 @@ func FuzzSign(f *testing.F) {
 	})
 }
 
+func FuzzVerifySignature(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		tp, err := GetTypeProvider(data)
+		if err != nil {
+			return
+		}
+		var sig Signature
+		err = tp.Fill(&sig)
+		if err != nil {
+			return
+		}
+		var pk PublicKey
+		err = tp.Fill(&pk)
+		if err != nil {
+			return
+		}
+		msg, err := tp.GetBytes()
+		if err != nil {
+			return
+		}
+		_, _ = VerifySignature(&sig, &pk, msg)
+	})
+}
+
 func FuzzVerifySignatureBytes(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		tp, err := GetTypeProvider(data)

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -58,7 +58,7 @@ func FuzzPublicKeyFromSecretKey(f *testing.F) {
 		if err != nil {
 			return
 		}
-		pk, err := PublicKeyFromSecretKey(&sk)
+		pk, _ := PublicKeyFromSecretKey(&sk)
 		require.NotNil(t, pk)
 	})
 }

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -39,7 +39,7 @@ func FuzzPublicKeyFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		bytes, err := tp.GetNBytes(BLSPublicKeyLength)
+		bytes, err := tp.GetNBytes(PublicKeyLength)
 		if err != nil {
 			return
 		}
@@ -58,7 +58,7 @@ func FuzzPublicKeyFromSecretKey(f *testing.F) {
 		if err != nil {
 			return
 		}
-		pk := PublicKeyFromSecretKey(&sk)
+		pk, err := PublicKeyFromSecretKey(&sk)
 		require.NotNil(t, pk)
 	})
 }
@@ -75,7 +75,7 @@ func FuzzSecretKeyFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		bytes, err := tp.GetNBytes(BLSSecretKeyLength)
+		bytes, err := tp.GetNBytes(SecretKeyLength)
 		if err != nil {
 			return
 		}
@@ -95,7 +95,7 @@ func FuzzSignatureFromBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		bytes, err := tp.GetNBytes(BLSSignatureLength)
+		bytes, err := tp.GetNBytes(SignatureLength)
 		if err != nil {
 			return
 		}
@@ -119,30 +119,6 @@ func FuzzSign(f *testing.F) {
 			return
 		}
 		Sign(&sk, msg)
-	})
-}
-
-func FuzzVerifySignature(f *testing.F) {
-	f.Fuzz(func(t *testing.T, data []byte) {
-		tp, err := GetTypeProvider(data)
-		if err != nil {
-			return
-		}
-		var sig Signature
-		err = tp.Fill(&sig)
-		if err != nil {
-			return
-		}
-		var pk PublicKey
-		err = tp.Fill(&pk)
-		if err != nil {
-			return
-		}
-		msg, err := tp.GetBytes()
-		if err != nil {
-			return
-		}
-		_ = VerifySignature(&sig, &pk, msg)
 	})
 }
 
@@ -174,11 +150,11 @@ func FuzzVerifySignatureBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		sigBytes, err := tp.GetNBytes(BLSSignatureLength)
+		sigBytes, err := tp.GetNBytes(SignatureLength)
 		if err != nil {
 			return
 		}
-		pkBytes, err := tp.GetNBytes(BLSPublicKeyLength)
+		pkBytes, err := tp.GetNBytes(PublicKeyLength)
 		if err != nil {
 			return
 		}

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -58,8 +58,10 @@ func FuzzPublicKeyFromSecretKey(f *testing.F) {
 		if err != nil {
 			return
 		}
-		pk, _ := PublicKeyFromSecretKey(&sk)
-		require.NotNil(t, pk)
+		pk, err := PublicKeyFromSecretKey(&sk)
+		if err != nil {
+			require.NotNil(t, pk)
+		}
 	})
 }
 

--- a/bls/bls_fuzz_test.go
+++ b/bls/bls_fuzz_test.go
@@ -166,7 +166,7 @@ func FuzzVerifySignatureBytes(f *testing.F) {
 		if err != nil {
 			return
 		}
-		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
+		_, _ = VerifySignatureBytes(sigBytes, pkBytes, msg)
 	})
 }
 
@@ -188,6 +188,6 @@ func FuzzVerifySignatureBytesValidLength(f *testing.F) {
 		if err != nil {
 			return
 		}
-		_, _ = VerifySignatureBytes(msg, sigBytes, pkBytes)
+		_, _ = VerifySignatureBytes(sigBytes, pkBytes, msg)
 	})
 }

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -19,6 +19,7 @@ func TestSecretToPubkey(t *testing.T) {
 		sk, err := SecretKeyFromBytes(tc.Input)
 		require.NoError(t, err)
 		pk, err := PublicKeyFromSecretKey(sk)
+		require.NoError(t, err)
 		require.Equal(t, PublicKeyToBytes(pk), tc.Output)
 	}
 }

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -18,8 +18,8 @@ func TestSecretToPubkey(t *testing.T) {
 	} {
 		sk, err := SecretKeyFromBytes(tc.Input)
 		require.NoError(t, err)
-		pk := PublicKeyFromSecretKey(sk)
-		require.Equal(t, pk.Compress(), tc.Output)
+		pk, err := PublicKeyFromSecretKey(sk)
+		require.Equal(t, PublicKeyToBytes(pk), tc.Output)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.18
 require (
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/ferranbt/fastssz v0.1.2-0.20220723134332-b3d3034a4575
+	github.com/kilic/bls12-381 v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.2
-	github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344
 	github.com/trailofbits/go-fuzz-utils v0.0.0-20210901195358-9657fcfd256c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/kilic/bls12-381 v0.1.0 h1:encrdjqKMEvabVQ7qYOKu1OvhqpK4s47wDYtNiPtlp4=
+github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0 h1:eyi1Ad2aNJMW95zcSbmGg7Cg6cq3ADwLpMAP96d8rF0=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
@@ -108,8 +110,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344 h1:m+8fKfQwCAy1QjzINvKe/pYtLjo2dl59x2w9YSEJxuY=
-github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
@@ -139,6 +139,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/types/builder.go
+++ b/types/builder.go
@@ -241,7 +241,7 @@ type GetPayloadResponse struct {
 }
 
 type Transactions struct {
-	Transactions [][]byte `ssz-max:"1048576,1073741824" ssz-size:"?,?"`
+	Transactions [][]byte `json:"transactions" ssz-max:"1048576,1073741824" ssz-size:"?,?"`
 }
 
 // BuilderGetValidatorsResponseEntry is an entry of the response array for getValidators: https://flashbots.notion.site/Relay-API-Spec-5fb0819366954962bc02e81cb33840f5#ba12faa6e2714825af4aa883bdef6d81

--- a/types/signing.go
+++ b/types/signing.go
@@ -68,7 +68,7 @@ func SignMessage(obj HashTreeRoot, d Domain, sk *bls.SecretKey) (Signature, erro
 		return Signature{}, err
 	}
 
-	signatureBytes := bls.Sign(sk, root[:]).Compress()
+	signatureBytes := bls.SignatureToBytes(bls.Sign(sk, root[:]))
 
 	var signature Signature
 	err = signature.FromSlice(signatureBytes)

--- a/types/signing.go
+++ b/types/signing.go
@@ -22,13 +22,13 @@ func init() {
 }
 
 type SigningData struct {
-	Root   Root   `ssz-size:"32"`
-	Domain Domain `ssz-size:"32"`
+	Root   Root   `json:"root" ssz-size:"32"`
+	Domain Domain `json:"domain" ssz-size:"32"`
 }
 
 type ForkData struct {
-	CurrentVersion        ForkVersion `ssz-size:"4"`
-	GenesisValidatorsRoot Root        `ssz-size:"32"`
+	CurrentVersion        ForkVersion `json:"current_version" ssz-size:"4"`
+	GenesisValidatorsRoot Root        `json:"genesis_validators_root" ssz-size:"32"`
 }
 
 type HashTreeRoot interface {

--- a/types/signing_test.go
+++ b/types/signing_test.go
@@ -32,9 +32,9 @@ func TestVerifySignature(t *testing.T) {
 	sig := bls.Sign(sk, root[:])
 	sig2, err := SignMessage(msg, domain, sk)
 	require.NoError(t, err)
-	require.Equal(t, sig.Compress(), sig2[:])
+	require.Equal(t, bls.SignatureToBytes(sig), sig2[:])
 
-	ok, err := VerifySignature(msg, domain, pk.Compress(), sig.Compress())
+	ok, err := VerifySignature(msg, domain, bls.PublicKeyToBytes(pk), bls.SignatureToBytes(sig))
 	require.NoError(t, err)
 	require.True(t, ok)
 }
@@ -44,7 +44,7 @@ func genValidatorRegistration(t require.TestingT, domain Domain) *SignedValidato
 	require.NoError(t, err)
 
 	var pubKey PublicKey
-	err = pubKey.FromSlice(pk.Compress())
+	err = pubKey.FromSlice(bls.PublicKeyToBytes(pk))
 	require.NoError(t, err)
 
 	msg := &RegisterValidatorRequestMessage{
@@ -89,7 +89,7 @@ func TestVerifySignatureManualPk(t *testing.T) {
 	pkBytes[0] = 0x01
 	sk2, err := bls.SecretKeyFromBytes(pkBytes)
 	require.NoError(t, err)
-	sig2 := bls.Sign(sk2, root2[:]).Compress()
+	sig2 := bls.SignatureToBytes(bls.Sign(sk2, root2[:]))
 	var signature2 Signature
 	err = signature2.FromSlice(sig2)
 	require.NoError(t, err)

--- a/types/utils.go
+++ b/types/utils.go
@@ -43,7 +43,7 @@ func (n *U256Str) Cmp(b *U256Str) int {
 }
 
 func BlsPublicKeyToPublicKey(blsPubKey *bls.PublicKey) (ret PublicKey, err error) {
-	err = ret.FromSlice(blsPubKey.Compress())
+	err = ret.FromSlice(bls.PublicKeyToBytes(blsPubKey))
 	return ret, err
 }
 


### PR DESCRIPTION
## 📝 Summary

Completely replace blst with kilic (a pure Go implementation of bls12-381).

## ⛱ Motivation and Context

Switching to a pure Go implementation would simplify a lot.

## 📚 References

BLS code is heavily inspired from:

* https://github.com/protolambda/bls12-381-util/blob/master/signatures.go

Associated with:

* https://github.com/flashbots/mev-boost/issues/478

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
