### PR TITLE
dependabot: don't update gnark-crypto

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -9,3 +9,6 @@ updates:
       interval: daily
     reviewers:
       - "metachris"
+      - "jtraglia"
+    ignore:
+      - dependency-name: "github.com/consensys/gnark-crypto" # we use an audited version, don't do auto upgrades


### PR DESCRIPTION
## 📝 Summary

We use the audited version of github.com/consensys/gnark-crypto and don't want to override that unless manually required.

The audited version being: `gnark-crypto v0.7.1-0.20220622171907-450e0206211e`

See also:

* https://github.com/flashbots/go-boost-utils/pull/62

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
