### PR TITLE
Update gnark-crypto to v0.9.1

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -82,7 +82,7 @@ func PublicKeyFromSecretKey(sk *SecretKey) (*PublicKey, error) {
 		return nil, ErrSecretKeyIsZero
 	}
 	skBigInt := new(big.Int)
-	sk.ToBigIntRegular(skBigInt)
+	sk.BigInt(skBigInt)
 	pkJac := new(bls12381.G1Jac).ScalarMultiplication(&g1OneJac, skBigInt)
 	return new(bls12381.G1Affine).FromJacobian(pkJac), nil
 }
@@ -105,7 +105,7 @@ func Sign(sk *SecretKey, msg []byte) *Signature {
 		panic(err)
 	}
 	skBigInt := new(big.Int)
-	sk.ToBigIntRegular(skBigInt)
+	sk.BigInt(skBigInt)
 	QJac := new(bls12381.G2Jac).FromAffine(&Q)
 	sigJac := new(bls12381.G2Jac).ScalarMultiplication(QJac, skBigInt)
 	return new(bls12381.G2Affine).FromJacobian(sigJac)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/flashbots/go-boost-utils
 go 1.20
 
 require (
-	github.com/consensys/gnark-crypto v0.7.1-0.20220622171907-450e0206211e
+	github.com/consensys/gnark-crypto v0.9.1
 	github.com/ethereum/go-ethereum v1.10.25
 	github.com/ferranbt/fastssz v0.1.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cb
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
-github.com/consensys/gnark-crypto v0.7.1-0.20220622171907-450e0206211e h1:/oPFrNXNDbVIAXTZ0fj55Q8wt4oEsFqsVPNEl6+cSQc=
-github.com/consensys/gnark-crypto v0.7.1-0.20220622171907-450e0206211e/go.mod h1:6HYNAhjXWmJ2udZqorw3nxaNS6MatAimF+DWVtJ+fBk=
+github.com/consensys/gnark-crypto v0.9.1 h1:mru55qKdWl3E035hAoh1jj9d7hVnYY5pfb6tmovSmII=
+github.com/consensys/gnark-crypto v0.9.1/go.mod h1:a2DQL4+5ywF6safEeZFEPGRiiGbjzGFRUN2sg06VuU4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## 📝 Summary

Update `gnark-crypto` to the latest version.

## ⛱ Motivation and Context

I think we should be using the latest version of gnark-crypto instead of the audited version. I think it's beneficial to get all of the minor improvements & bug fixes that the newer versions include.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
