### PR TITLE
Unpin gnark-crypto in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,5 +10,3 @@ updates:
     reviewers:
       - "metachris"
       - "jtraglia"
-    ignore:
-      - dependency-name: "github.com/consensys/gnark-crypto" # we use an audited version, don't do auto upgrades


### PR DESCRIPTION
## 📝 Summary

Remove gnark-crypto from the ignore section for dependabot.

## ⛱ Motivation and Context

Because there was a bug fix in the latest version, we are no longer using the audited version of gnark-crypto. I do not think it's necessary to pin this anymore. Maybe reconsider pinning if there's another audit of a stable release.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
