### PR TITLE
Verify signature with message root

### DIFF
--- a/ssz/ssz.go
+++ b/ssz/ssz.go
@@ -76,3 +76,13 @@ func VerifySignature(obj ObjWithHashTreeRoot, d phase0.Domain, pkBytes, sigBytes
 
 	return bls.VerifySignatureBytes(msg[:], sigBytes, pkBytes)
 }
+
+func VerifySignatureRoot(root phase0.Root, d phase0.Domain, pkBytes, sigBytes []byte) (bool, error) {
+	signingData := phase0.SigningData{ObjectRoot: root, Domain: d}
+	msg, err := signingData.HashTreeRoot()
+	if err != nil {
+		return false, err
+	}
+
+	return bls.VerifySignatureBytes(msg[:], sigBytes, pkBytes)
+}


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Attestant types has helper functions that return `HashTreeRoot()` instead of the object to compute the root. As the library does not return helper functions to return an interface with `HashTreeRoot()`, we add helper functions that verify the signature directly with the computed root.

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
