### PR TITLE
Add blob sidecar domain

### DIFF
--- a/ssz/ssz.go
+++ b/ssz/ssz.go
@@ -13,6 +13,7 @@ var (
 	DomainBuilder = ComputeDomain(DomainTypeAppBuilder, phase0.Version{}, phase0.Root{})
 
 	DomainTypeBeaconProposer = phase0.DomainType{0x00, 0x00, 0x00, 0x00}
+	DomainTypeBlobSidecar    = phase0.DomainType{0x0B, 0x00, 0x00, 0x00}
 	DomainTypeAppBuilder     = phase0.DomainType{0x00, 0x00, 0x00, 0x01}
 )
 


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->
Add deneb [domain type](https://github.com/ethereum/consensus-specs/blob/8acb254511d61d3ffcddc262da024646884a8a82/specs/deneb/beacon-chain.md#domain-types) for blob sidecars to verify blob signatures on the relay.

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
