### PR TITLE
Improve HexToPubkey & HexToSignature

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,7 @@
 linters:
   enable-all: true
   disable:
+    - dupl
     - exhaustruct
     - funlen
     - gochecknoglobals

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -65,7 +65,7 @@ func HexToAddress(s string) (ret bellatrix.ExecutionAddress, err error) {
 func HexToPubkey(s string) (ret phase0.BLSPubKey, err error) {
 	bytes, err := hexutil.Decode(s)
 	if err != nil {
-		return phase0.BLSPubKey{}, ErrInvalidPubkey
+		return phase0.BLSPubKey{}, err
 	}
 	if len(bytes) != len(ret) {
 		return phase0.BLSPubKey{}, ErrLength
@@ -82,7 +82,7 @@ func HexToPubkey(s string) (ret phase0.BLSPubKey, err error) {
 func HexToSignature(s string) (ret phase0.BLSSignature, err error) {
 	bytes, err := hexutil.Decode(s)
 	if err != nil {
-		return phase0.BLSSignature{}, ErrInvalidSignature
+		return phase0.BLSSignature{}, err
 	}
 	if len(bytes) != len(ret) {
 		return phase0.BLSSignature{}, ErrLength

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"io"
 	"math/big"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	utilbellatrix "github.com/attestantio/go-eth2-client/util/bellatrix"
 	utilcapella "github.com/attestantio/go-eth2-client/util/capella"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -64,6 +64,9 @@ func HexToAddress(s string) (ret bellatrix.ExecutionAddress, err error) {
 // HexToPubkey takes a hex string and returns a PublicKey
 func HexToPubkey(s string) (ret phase0.BLSPubKey, err error) {
 	bytes, err := hexutil.Decode(s)
+	if err != nil {
+		return phase0.BLSPubKey{}, ErrInvalidPubkey
+	}
 	if len(bytes) != len(ret) {
 		return phase0.BLSPubKey{}, ErrLength
 	}
@@ -78,6 +81,9 @@ func HexToPubkey(s string) (ret phase0.BLSPubKey, err error) {
 // HexToSignature takes a hex string and returns a Signature
 func HexToSignature(s string) (ret phase0.BLSSignature, err error) {
 	bytes, err := hexutil.Decode(s)
+	if err != nil {
+		return phase0.BLSSignature{}, ErrInvalidSignature
+	}
 	if len(bytes) != len(ret) {
 		return phase0.BLSSignature{}, ErrLength
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"io"
 	"math/big"
 
@@ -28,6 +29,8 @@ var (
 	ErrNilPayload         = errors.New("nil payload")
 	ErrUnsupportedVersion = errors.New("unsupported version")
 	ErrUnknownVersion     = errors.New("unknown version")
+	ErrInvalidPubkey      = errors.New("invalid pubkey")
+	ErrInvalidSignature   = errors.New("invalid signature")
 )
 
 func BlsPublicKeyToPublicKey(blsPubKey *bls.PublicKey) (ret phase0.BLSPubKey, err error) {
@@ -64,6 +67,10 @@ func HexToPubkey(s string) (ret phase0.BLSPubKey, err error) {
 	if len(bytes) != len(ret) {
 		return phase0.BLSPubKey{}, ErrLength
 	}
+	_, err = new(bls12381.G1Affine).SetBytes(bytes)
+	if err != nil {
+		return phase0.BLSPubKey{}, ErrInvalidPubkey
+	}
 	copy(ret[:], bytes)
 	return
 }
@@ -73,6 +80,10 @@ func HexToSignature(s string) (ret phase0.BLSSignature, err error) {
 	bytes, err := hexutil.Decode(s)
 	if len(bytes) != len(ret) {
 		return phase0.BLSSignature{}, ErrLength
+	}
+	_, err = new(bls12381.G2Affine).SetBytes(bytes)
+	if err != nil {
+		return phase0.BLSSignature{}, ErrInvalidSignature
 	}
 	copy(ret[:], bytes)
 	return

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -36,30 +36,46 @@ func TestHexToPubkey(t *testing.T) {
 		name   string
 		pubkey string
 
-		expectedErr error
+		valid       bool
+		expectedErr string
 	}{
 		{
-			name:        "Valid pubkey",
-			pubkey:      "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae",
-			expectedErr: nil,
+			name:   "Valid pubkey",
+			pubkey: "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae",
+			valid:  true,
 		},
 		{
 			name:        "Invalid pubkey (wrong length)",
 			pubkey:      "0x123456",
-			expectedErr: ErrLength,
+			valid:       false,
+			expectedErr: "invalid length",
 		},
 		{
 			name:        "Invalid pubkey (not on the curve)",
 			pubkey:      "0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f",
-			expectedErr: ErrInvalidPubkey,
+			valid:       false,
+			expectedErr: "invalid pubkey",
+		},
+		{
+			name:        "Invalid pubkey (no 0x prefix)",
+			pubkey:      "this is not hex",
+			valid:       false,
+			expectedErr: "hex string without 0x prefix",
+		},
+		{
+			name:        "Invalid pubkey (not hex)",
+			pubkey:      "0xthisisnothex",
+			valid:       false,
+			expectedErr: "invalid hex string",
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := HexToPubkey(tt.pubkey)
-			require.Equal(t, tt.expectedErr, err)
-			if tt.expectedErr == nil {
+			if !tt.valid {
+				require.EqualError(t, err, tt.expectedErr)
+			} else {
 				require.Equal(t, tt.pubkey, result.String())
 			}
 		})
@@ -71,30 +87,46 @@ func TestHexToSignature(t *testing.T) {
 		name      string
 		signature string
 
-		expectedErr error
+		valid       bool
+		expectedErr string
 	}{
 		{
-			name:        "Valid signature",
-			signature:   "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712",
-			expectedErr: nil,
+			name:      "Valid signature",
+			signature: "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712",
+			valid:     true,
 		},
 		{
 			name:        "Invalid signature (wrong length)",
 			signature:   "0x123456",
-			expectedErr: ErrLength,
+			valid:       false,
+			expectedErr: "invalid length",
 		},
 		{
 			name:        "Invalid signature (not on the curve)",
 			signature:   "0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a",
-			expectedErr: ErrInvalidSignature,
+			valid:       false,
+			expectedErr: "invalid signature",
+		},
+		{
+			name:        "Invalid signature (no 0x prefix)",
+			signature:   "this is not hex",
+			valid:       false,
+			expectedErr: "hex string without 0x prefix",
+		},
+		{
+			name:        "Invalid pubkey (not hex)",
+			signature:   "0xthisisnothex",
+			valid:       false,
+			expectedErr: "invalid hex string",
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := HexToSignature(tt.signature)
-			require.Equal(t, tt.expectedErr, err)
-			if tt.expectedErr == nil {
+			if !tt.valid {
+				require.EqualError(t, err, tt.expectedErr)
+			} else {
 				require.Equal(t, tt.signature, result.String())
 			}
 		})

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -35,18 +35,28 @@ func TestHexToPubkey(t *testing.T) {
 	_, err := HexToPubkey("0x01")
 	require.Error(t, err)
 
-	a, err := HexToPubkey("0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f")
+	// This is an invalid pubkey
+	_, err = HexToPubkey("0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f")
+	require.Error(t, err)
+
+	// This is a valid pubkey
+	a, err := HexToPubkey("0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae")
 	require.NoError(t, err)
-	require.Equal(t, "0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f", a.String())
+	require.Equal(t, "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae", a.String())
 }
 
 func TestHexToSignature(t *testing.T) {
 	_, err := HexToSignature("0x01")
 	require.Error(t, err)
 
-	a, err := HexToSignature("0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a")
+	// This is an invalid signature
+	_, err = HexToSignature("0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a")
+	require.Error(t, err)
+
+	// This is a valid signature
+	a, err := HexToSignature("0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712")
 	require.NoError(t, err)
-	require.Equal(t, "0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a", a.String())
+	require.Equal(t, "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712", a.String())
 }
 
 func TestComputeHash(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -114,7 +114,7 @@ func TestHexToSignature(t *testing.T) {
 			expectedErr: "hex string without 0x prefix",
 		},
 		{
-			name:        "Invalid pubkey (not hex)",
+			name:        "Invalid signature (not hex)",
 			signature:   "0xthisisnothex",
 			valid:       false,
 			expectedErr: "invalid hex string",

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -32,31 +32,73 @@ func TestHexToAddress(t *testing.T) {
 }
 
 func TestHexToPubkey(t *testing.T) {
-	_, err := HexToPubkey("0x01")
-	require.Error(t, err)
+	testCases := []struct {
+		name   string
+		pubkey string
 
-	// This is an invalid pubkey
-	_, err = HexToPubkey("0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f")
-	require.Error(t, err)
+		expectedErr error
+	}{
+		{
+			name:        "Valid pubkey",
+			pubkey:      "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae",
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid pubkey (wrong length)",
+			pubkey:      "0x123456",
+			expectedErr: ErrLength,
+		},
+		{
+			name:        "Invalid pubkey (not on the curve)",
+			pubkey:      "0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f",
+			expectedErr: ErrInvalidPubkey,
+		},
+	}
 
-	// This is a valid pubkey
-	a, err := HexToPubkey("0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae")
-	require.NoError(t, err)
-	require.Equal(t, "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae", a.String())
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HexToPubkey(tt.pubkey)
+			require.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr == nil {
+				require.Equal(t, tt.pubkey, result.String())
+			}
+		})
+	}
 }
 
 func TestHexToSignature(t *testing.T) {
-	_, err := HexToSignature("0x01")
-	require.Error(t, err)
+	testCases := []struct {
+		name      string
+		signature string
 
-	// This is an invalid signature
-	_, err = HexToSignature("0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a")
-	require.Error(t, err)
+		expectedErr error
+	}{
+		{
+			name:        "Valid signature",
+			signature:   "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712",
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid signature (wrong length)",
+			signature:   "0x123456",
+			expectedErr: ErrLength,
+		},
+		{
+			name:        "Invalid signature (not on the curve)",
+			signature:   "0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a",
+			expectedErr: ErrInvalidSignature,
+		},
+	}
 
-	// This is a valid signature
-	a, err := HexToSignature("0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712")
-	require.NoError(t, err)
-	require.Equal(t, "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712", a.String())
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := HexToSignature(tt.signature)
+			require.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr == nil {
+				require.Equal(t, tt.signature, result.String())
+			}
+		})
+	}
 }
 
 func TestComputeHash(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -33,39 +33,32 @@ func TestHexToAddress(t *testing.T) {
 
 func TestHexToPubkey(t *testing.T) {
 	testCases := []struct {
-		name   string
-		pubkey string
-
-		valid       bool
+		name        string
+		pubkey      string
 		expectedErr string
 	}{
 		{
 			name:   "Valid pubkey",
 			pubkey: "0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae",
-			valid:  true,
 		},
 		{
 			name:        "Invalid pubkey (wrong length)",
 			pubkey:      "0x123456",
-			valid:       false,
 			expectedErr: "invalid length",
 		},
 		{
 			name:        "Invalid pubkey (not on the curve)",
 			pubkey:      "0xed7f862045422bd51ba732730ce993c94d2545e5db1112102026343904fcdf6f5cf37926a3688444703772ed80fa223f",
-			valid:       false,
 			expectedErr: "invalid pubkey",
 		},
 		{
 			name:        "Invalid pubkey (no 0x prefix)",
 			pubkey:      "this is not hex",
-			valid:       false,
 			expectedErr: "hex string without 0x prefix",
 		},
 		{
 			name:        "Invalid pubkey (not hex)",
 			pubkey:      "0xthisisnothex",
-			valid:       false,
 			expectedErr: "invalid hex string",
 		},
 	}
@@ -73,9 +66,10 @@ func TestHexToPubkey(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := HexToPubkey(tt.pubkey)
-			if !tt.valid {
+			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
+				require.NoError(t, err)
 				require.Equal(t, tt.pubkey, result.String())
 			}
 		})
@@ -84,39 +78,32 @@ func TestHexToPubkey(t *testing.T) {
 
 func TestHexToSignature(t *testing.T) {
 	testCases := []struct {
-		name      string
-		signature string
-
-		valid       bool
+		name        string
+		signature   string
 		expectedErr string
 	}{
 		{
 			name:      "Valid signature",
 			signature: "0x8069aa021666163aae46d353c348aa913fb5050062e05ab764c8eef99407a8befcd46190b30cc40e40ee8c197356959816799d62e85f640ef76b4be1b08a741949230fbde49589125537daad06c23a66838725d89e3504bc21559a91534f6712",
-			valid:     true,
 		},
 		{
 			name:        "Invalid signature (wrong length)",
 			signature:   "0x123456",
-			valid:       false,
 			expectedErr: "invalid length",
 		},
 		{
 			name:        "Invalid signature (not on the curve)",
 			signature:   "0xb8f03e639b91fa8e9892f66c798f07f6e7b3453234f643b2c06a35c5149cf6d85e4e1572c33549fe749292445fbff9e0739c78159324c35dc1a90e5745ca70c8caf1b63fb6678d81bd2d5cb6baeb1462df7a93877d0e22a31dd6438334536d9a",
-			valid:       false,
 			expectedErr: "invalid signature",
 		},
 		{
 			name:        "Invalid signature (no 0x prefix)",
 			signature:   "this is not hex",
-			valid:       false,
 			expectedErr: "hex string without 0x prefix",
 		},
 		{
 			name:        "Invalid signature (not hex)",
 			signature:   "0xthisisnothex",
-			valid:       false,
 			expectedErr: "invalid hex string",
 		},
 	}
@@ -124,9 +111,10 @@ func TestHexToSignature(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := HexToSignature(tt.signature)
-			if !tt.valid {
+			if tt.expectedErr != "" {
 				require.EqualError(t, err, tt.expectedErr)
 			} else {
+				require.NoError(t, err)
 				require.Equal(t, tt.signature, result.String())
 			}
 		})


### PR DESCRIPTION
## 📝 Summary

This PR adds checks to `HexToPubkey` and `HexToSignature` to ensure they are valid points.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
